### PR TITLE
Use the correct metrics calls for the token we have.

### DIFF
--- a/lib/routes/messageApi.js
+++ b/lib/routes/messageApi.js
@@ -199,7 +199,7 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
      */
     getNotes : function(req, res, next) {
       log.debug('getNotes: params[%j], url[%s], method[%s]', req.params, req.url, req.method);
-      metrics.postServer('getNotes', {}, req._sessionToken);
+      metrics.postThisUser('getNotes', {}, req._sessionToken);
 
       res.setHeader('content-type', 'application/json');
 
@@ -246,7 +246,7 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
     getThread : function(req, res, next) {
 
       log.debug('getThread: params[%j], url[%s], method[%s]', req.params, req.url, req.method);
-      metrics.postServer('getThread', {}, req._sessionToken);
+      metrics.postThisUser('getThread', {}, req._sessionToken);
 
       res.setHeader('content-type', 'application/json');
 
@@ -285,8 +285,8 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
      * @return next
      */
     addThread : function(req, res, next) {
-      log.debug('add: params[%j], url[%s], method[%s]', req.params, req.url, req.method);
-      metrics.postServer('addThread', {}, req._sessionToken);
+      log.debug('addThread: params[%j], url[%s], method[%s]', req.params, req.url, req.method);
+      metrics.postThisUser('addThread', {}, req._sessionToken);
 
       var missing = validate.incomingMessage(req.params.message);
 
@@ -326,7 +326,7 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
      * @return next
      */
     replyToThread : function(req, res, next) {
-      log.debug('add: params[%j], url[%s], method[%s]', req.params, req.url, req.method);
+      log.debug('replyToThread: params[%j], url[%s], method[%s]', req.params, req.url, req.method);
       metrics.postServer('replyToThread', {}, req._sessionToken);
 
       var missing = validate.incomingMessage(req.params.message);
@@ -364,7 +364,7 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
      */
     editMessage : function(req, res, next) {
       log.debug('editMessage: params[%j], url[%s], method[%s]', req.params, req.url, req.method);
-      metrics.postServer('editMessage', {}, req._sessionToken);
+      metrics.postThisUser('editMessage', {}, req._sessionToken);
 
       var missing = validate.incomingEdit(req.params.message);
 
@@ -398,7 +398,7 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
      */
     removeMessage : function(req, res, next) {
       log.debug('removeMessage: params[%j], url[%s], method[%s]', req.params, req.url, req.method);
-      metrics.postServer('removeMessage', {}, req._sessionToken);
+      metrics.postThisUser('removeMessage', {}, req._sessionToken);
 
       res.setHeader('content-type', 'application/json');
 


### PR DESCRIPTION
This fixes https://trello.com/c/CyslDw2q/131-message-api-has-metrics-calls-contained-but-these-are-not-being-logged-through-to-kissmetrics
