### PR TITLE
Use the correct metrics calls for the kind of token we have.

### DIFF
--- a/lib/routes/messageApi.js
+++ b/lib/routes/messageApi.js
@@ -114,7 +114,7 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
      */
     findById : function(req, res, next) {
       log.debug('findById: params[%j], url[%s], method[%s]', req.params, req.url, req.method);
-      metrics.postServer('findById', {}, req._sessionToken);
+      metrics.postThisUser('findById', {}, req._sessionToken);
 
       res.setHeader('content-type', 'application/json');
       var messageId = req.params.msgid;
@@ -150,7 +150,7 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
      */
     findAllById : function(req, res, next) {
       log.debug('findAllById: params[%j], url[%s], method[%s]', req.params, req.url, req.method);
-      metrics.postServer('findAllById', {}, req._sessionToken);
+      metrics.postThisUser('findAllById', {}, req._sessionToken);
 
       res.setHeader('content-type', 'application/json');
 
@@ -327,7 +327,7 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
      */
     replyToThread : function(req, res, next) {
       log.debug('replyToThread: params[%j], url[%s], method[%s]', req.params, req.url, req.method);
-      metrics.postServer('replyToThread', {}, req._sessionToken);
+      metrics.postThisUser('replyToThread', {}, req._sessionToken);
 
       var missing = validate.incomingMessage(req.params.message);
 

--- a/test/integration/messagesService_integration_tests.js
+++ b/test/integration/messagesService_integration_tests.js
@@ -28,7 +28,7 @@ var env = {
 };
 
 var userApiClient = mockableObject.make('checkToken');
-var dummyMetrics = mockableObject.make('postServer');
+var dummyMetrics = mockableObject.make('postThisUser');
 var gatekeeperHandler = require('../helpers/mockGatekeeperHandler')();
 
 //mock metrics
@@ -70,11 +70,11 @@ describe('message service', function() {
   }
 
   function mockMetrics() {
-    sinon.stub(dummyMetrics,'postServer');
+    sinon.stub(dummyMetrics,'postThisUser');
   }
 
   function expectMetricsToBeCalled() {
-    expect(dummyMetrics.postServer).to.have.been.calledOnce;
+    expect(dummyMetrics.postThisUser).to.have.been.calledOnce;
   }
 
   /*
@@ -956,7 +956,7 @@ describe('message service', function() {
       .expect(200)
       .end(function(err, res) {
         if (err) return done(err);
-        expect(dummyMetrics.postServer).to.have.not.been.called;
+        expect(dummyMetrics.postThisUser).to.have.not.been.called;
         done();
       });
     });


### PR DESCRIPTION
Correct metrics branch. This fixes https://trello.com/c/CyslDw2q/131-message-api-has-metrics-calls-contained-but-these-are-not-being-logged-through-to-kissmetrics
