### PR TITLE
allow save and return of GUIDs; update tests accordingly

### DIFF
--- a/lib/validation/format.js
+++ b/lib/validation/format.js
@@ -21,6 +21,7 @@ var sundial = require('sundial');
 exports.incomingMessage = function(inBound)
 {
   return {
+    guid: inBound.guid,
     userid : inBound.userid ,
     groupid : inBound.groupid ,
     parentmessage : null,
@@ -34,6 +35,7 @@ exports.incomingMessage = function(inBound)
 exports.incomingReply = function(inBound,parentId)
 {
   return {
+    guid: inBound.guid,
     userid : inBound.userid ,
     groupid : inBound.groupid ,
     parentmessage : parentId,
@@ -58,6 +60,10 @@ exports.incomingEdit = function(edits)
     toEdit.timestamp = edits.timestamp;
   }
 
+  if(!_.isEmpty(edits.guid)){
+    toEdit.guid = edits.guid;
+  }
+
   return toEdit;
 };
 
@@ -65,6 +71,7 @@ exports.outgoingMessage = function(data,id)
 {
   return {
     id : id,
+    guid: data.guid,
     parentmessage: data.parentmessage,
     userid : data.userid,
     groupid : data.groupid,

--- a/lib/validation/validate.js
+++ b/lib/validation/validate.js
@@ -35,7 +35,7 @@ exports.incomingMessage = function(message)
 {
   return hasProperties(
     message,
-    ['userid','groupid','timestamp','messagetext']
+    ['guid','userid','groupid','timestamp','messagetext']
   );
 };
 

--- a/test/helpers/testMessagesData.js
+++ b/test/helpers/testMessagesData.js
@@ -24,6 +24,7 @@ var testMessagesData = {
 // A related set of messages
 testMessagesData.noteAndComments = [
   {
+    guid: 'abcde',
     parentmessage : null,
     userid: '12121212',
     groupid: '777',
@@ -32,6 +33,7 @@ testMessagesData.noteAndComments = [
     messagetext: 'In three words I can sum up everything I have learned about life: it goes on.'
   },
   {
+    guid: 'abcde',
     parentmessage:null,
     userid: '232323',
     groupid: '777',
@@ -40,6 +42,7 @@ testMessagesData.noteAndComments = [
     messagetext: 'Second message.'
   },
   {
+    guid: 'abcde',
     parentmessage:null,
     userid: '232323',
     groupid: '777',
@@ -48,6 +51,7 @@ testMessagesData.noteAndComments = [
     messagetext: 'Third message.'
   },
   {
+    guid: 'abcde',
     parentmessage:null,
     userid: '232323',
     groupid: '777',
@@ -59,6 +63,7 @@ testMessagesData.noteAndComments = [
 
 // One off group with no other related groups
 testMessagesData.note = {
+  guid: 'abcde',
   parentmessage:null,
   userid: '12121212',
   groupid: '999',

--- a/test/integration/messagesService_integration_tests.js
+++ b/test/integration/messagesService_integration_tests.js
@@ -84,6 +84,7 @@ describe('message service', function() {
     //should be these properties
     var keys = [
       'id',
+      'guid',
       'parentmessage',
       'groupid',
       'userid',
@@ -559,6 +560,7 @@ describe('message service', function() {
     it('only saves core message fields', function(done) {
 
       var messageWithExtras = {
+        guid: 'abcde',
         parentmessage : null,
         userid: '12121212',
         groupid: '777',
@@ -627,7 +629,7 @@ describe('message service', function() {
       .end(function(err, res) {
         if (err) return done(err);
         var message = res.body;
-        expect(message).equal('{"groupid":"property is required","messagetext":"property is required"}');
+        expect(message).equal('{"guid":"property is required","groupid":"property is required","messagetext":"property is required"}');
         done();
       });
     });
@@ -716,6 +718,7 @@ describe('message service', function() {
     it('only saves core message fields', function(done) {
 
       var replyWithExtras = {
+        guid: 'abcde',
         userid: '12121212',
         groupid: '777',
         timestamp: '2013-11-28T23:07:40+00:00',
@@ -766,7 +769,7 @@ describe('message service', function() {
       .end(function(err, res) {
         if (err) return done(err);
         var message = res.body;
-        expect(message).equal('{"groupid":"property is required","messagetext":"property is required"}');
+        expect(message).equal('{"guid":"property is required","groupid":"property is required","messagetext":"property is required"}');
         done();
       });
     });

--- a/test/integration/mongoHandler_integration_tests.js
+++ b/test/integration/mongoHandler_integration_tests.js
@@ -37,10 +37,11 @@ describe('mongo handler', function() {
 
     function messageContentToReturn(saved,toReturn,cb){
       //should be these properties
-      expect(Object.keys(toReturn).length).to.equal(7);
+      expect(Object.keys(toReturn).length).to.equal(8);
 
       expect(toReturn).to.contain.keys(
         'id',
+        'guid',
         'parentmessage',
         'groupid',
         'userid',
@@ -51,6 +52,7 @@ describe('mongo handler', function() {
 
       //these properties must be returned with a value
       expect(toReturn.id).to.exist;
+      expect(toReturn.guid).to.exist;
       expect(toReturn.groupid).to.exist;
       expect(toReturn.userid).to.exist;
       expect(toReturn.timestamp).to.exist;
@@ -58,6 +60,7 @@ describe('mongo handler', function() {
       expect(toReturn.messagetext).to.exist;
 
       //equals what was saved
+      expect(toReturn.guid).to.equal(saved.guid);
       expect(toReturn.groupid).to.equal(saved.groupid);
       expect(toReturn.userid).to.equal(saved.userid);
       expect(toReturn.timestamp).to.equal(saved.timestamp);
@@ -88,6 +91,7 @@ describe('mongo handler', function() {
     it('will get message with requested id', function(done) {
 
       var messageToSave = {
+        guid: 'abcde',
         parentmessage : null,
         groupid : '123',
         userid : '456',

--- a/test/unit/messageApi_tests.js
+++ b/test/unit/messageApi_tests.js
@@ -135,6 +135,7 @@ describe('message API', function() {
       it('ignores the parentmessage as it will be created the parent', function(done) {
 
         var parentMessage = {
+          guid: 'abcde',
           userid: '12345',
           groupid: '4567',
           parentmessage:'',
@@ -171,6 +172,7 @@ describe('message API', function() {
       it('does not require the parentmessage to be set', function(done) {
 
         var replyWithParentNotSet = {
+          guid: 'abcde',
           userid: '12345',
           groupid: '4567',
           parentmessage: null ,


### PR DESCRIPTION
Perhaps WIP. Have a look-see @jh-bate? This seemed like the simplest set of updates to store & return GUIDs. platform-client and blip PRs to follow.