### PR TITLE
allow storage of GUID on new message threads and replies

### DIFF
--- a/lib/validation/format.js
+++ b/lib/validation/format.js
@@ -21,8 +21,9 @@ var sundial = require('sundial');
 exports.incomingMessage = function(inBound)
 {
   return {
-    userid : inBound.userid ,
-    groupid : inBound.groupid ,
+    guid : inBound.guid,
+    userid : inBound.userid,
+    groupid : inBound.groupid,
     parentmessage : null,
     timestamp : inBound.timestamp,
     createdtime : sundial.utcDateString(),
@@ -34,8 +35,9 @@ exports.incomingMessage = function(inBound)
 exports.incomingReply = function(inBound,parentId)
 {
   return {
-    userid : inBound.userid ,
-    groupid : inBound.groupid ,
+    guid: inBound.guid,
+    userid : inBound.userid,
+    groupid : inBound.groupid,
     parentmessage : parentId,
     timestamp : inBound.timestamp,
     createdtime : sundial.utcDateString(),
@@ -65,7 +67,8 @@ exports.outgoingMessage = function(data,id)
 {
   return {
     id : id,
-    parentmessage: data.parentmessage,
+    guid : data.guid,
+    parentmessage : data.parentmessage,
     userid : data.userid,
     groupid : data.groupid,
     timestamp : data.timestamp,

--- a/lib/validation/validate.js
+++ b/lib/validation/validate.js
@@ -35,7 +35,7 @@ exports.incomingMessage = function(message)
 {
   return hasProperties(
     message,
-    ['userid','groupid','timestamp','messagetext']
+    ['guid','userid','groupid','timestamp','messagetext']
   );
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-api",
-  "version": "0.4.0-beta",
+  "version": "0.4.1-beta",
   "description": "Tidepool Message API.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-api",
-  "version": "0.3.16",
+  "version": "0.4.0-beta",
   "description": "Tidepool Message API.",
   "main": "lib/index.js",
   "directories": {

--- a/test/helpers/testMessagesData.js
+++ b/test/helpers/testMessagesData.js
@@ -24,6 +24,7 @@ var testMessagesData = {
 // A related set of messages
 testMessagesData.noteAndComments = [
   {
+    guid: 'abcde',
     parentmessage : null,
     userid: '12121212',
     groupid: '777',
@@ -32,6 +33,7 @@ testMessagesData.noteAndComments = [
     messagetext: 'In three words I can sum up everything I have learned about life: it goes on.'
   },
   {
+    guid: 'abcde',
     parentmessage:null,
     userid: '232323',
     groupid: '777',
@@ -40,6 +42,7 @@ testMessagesData.noteAndComments = [
     messagetext: 'Second message.'
   },
   {
+    guid: 'abcde',
     parentmessage:null,
     userid: '232323',
     groupid: '777',
@@ -48,6 +51,7 @@ testMessagesData.noteAndComments = [
     messagetext: 'Third message.'
   },
   {
+    guid: 'abcde',
     parentmessage:null,
     userid: '232323',
     groupid: '777',
@@ -59,6 +63,7 @@ testMessagesData.noteAndComments = [
 
 // One off group with no other related groups
 testMessagesData.note = {
+  guid: 'abcde',
   parentmessage:null,
   userid: '12121212',
   groupid: '999',

--- a/test/integration/messagesService_integration_tests.js
+++ b/test/integration/messagesService_integration_tests.js
@@ -560,6 +560,7 @@ describe('message service', function() {
     it('only saves core message fields', function(done) {
 
       var messageWithExtras = {
+        guid: 'abcde',
         parentmessage : null,
         userid: '12121212',
         groupid: '777',
@@ -628,7 +629,7 @@ describe('message service', function() {
       .end(function(err, res) {
         if (err) return done(err);
         var message = res.body;
-        expect(message).equal('{"groupid":"property is required","messagetext":"property is required"}');
+        expect(message).equal('{"guid":"property is required","groupid":"property is required","messagetext":"property is required"}');
         done();
       });
     });
@@ -717,6 +718,7 @@ describe('message service', function() {
     it('only saves core message fields', function(done) {
 
       var replyWithExtras = {
+        guid: 'abcde',
         userid: '12121212',
         groupid: '777',
         timestamp: '2013-11-28T23:07:40+00:00',
@@ -767,7 +769,7 @@ describe('message service', function() {
       .end(function(err, res) {
         if (err) return done(err);
         var message = res.body;
-        expect(message).equal('{"groupid":"property is required","messagetext":"property is required"}');
+        expect(message).equal('{"guid":"property is required","groupid":"property is required","messagetext":"property is required"}');
         done();
       });
     });

--- a/test/integration/messagesService_integration_tests.js
+++ b/test/integration/messagesService_integration_tests.js
@@ -84,6 +84,7 @@ describe('message service', function() {
     //should be these properties
     var keys = [
       'id',
+      'guid',
       'parentmessage',
       'groupid',
       'userid',

--- a/test/integration/mongoHandler_integration_tests.js
+++ b/test/integration/mongoHandler_integration_tests.js
@@ -37,10 +37,11 @@ describe('mongo handler', function() {
 
     function messageContentToReturn(saved,toReturn,cb){
       //should be these properties
-      expect(Object.keys(toReturn).length).to.equal(7);
+      expect(Object.keys(toReturn).length).to.equal(8);
 
       expect(toReturn).to.contain.keys(
         'id',
+        'guid',
         'parentmessage',
         'groupid',
         'userid',
@@ -51,6 +52,7 @@ describe('mongo handler', function() {
 
       //these properties must be returned with a value
       expect(toReturn.id).to.exist;
+      expect(toReturn.guid).to.exist;
       expect(toReturn.groupid).to.exist;
       expect(toReturn.userid).to.exist;
       expect(toReturn.timestamp).to.exist;
@@ -58,6 +60,7 @@ describe('mongo handler', function() {
       expect(toReturn.messagetext).to.exist;
 
       //equals what was saved
+      expect(toReturn.guid).to.equal(saved.guid);
       expect(toReturn.groupid).to.equal(saved.groupid);
       expect(toReturn.userid).to.equal(saved.userid);
       expect(toReturn.timestamp).to.equal(saved.timestamp);
@@ -88,6 +91,7 @@ describe('mongo handler', function() {
     it('will get message with requested id', function(done) {
 
       var messageToSave = {
+        guid: 'abcde',
         parentmessage : null,
         groupid : '123',
         userid : '456',

--- a/test/unit/messageApi_tests.js
+++ b/test/unit/messageApi_tests.js
@@ -135,6 +135,7 @@ describe('message API', function() {
       it('ignores the parentmessage as it will be created the parent', function(done) {
 
         var parentMessage = {
+          guid: 'abcde',
           userid: '12345',
           groupid: '4567',
           parentmessage:'',
@@ -171,6 +172,7 @@ describe('message API', function() {
       it('does not require the parentmessage to be set', function(done) {
 
         var replyWithParentNotSet = {
+          guid: 'abcde',
           userid: '12345',
           groupid: '4567',
           parentmessage: null ,


### PR DESCRIPTION
Here's the simpler version @jh-bate - just make sure we store and return GUIDs on new message threads and replies.

The logic should be more nuanced if we expect some messages to come through without GUIDs (to prevent storing a null GUID) but I think if we just get blip and clamshell out first with the new platform-client, that shouldn't be a problem, so I kept it simple. LMK if you disagree.