### PR TITLE
Updates to support delete user

### DIFF
--- a/lib/handler/seagullHandler.js
+++ b/lib/handler/seagullHandler.js
@@ -84,7 +84,7 @@ module.exports = function(seagullClient, userClient) {
                 log.error('getting profile ',error);
                 return callback();
               }
-              resolvedUsers[userId] = profile;
+              resolvedUsers[userId] = _.pick(profile, 'fullName');
               done();
             });
           });

--- a/lib/routes/messageApi.js
+++ b/lib/routes/messageApi.js
@@ -39,14 +39,21 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
    * Resolve from the userid the profile of user that created the message
    */
   function resolveUserProfiles(messages, cb){
-    var ids = _(messages).pluck('userid').uniq().valueOf();
+    var ids = _(messages).pluck('userid').compact().uniq().valueOf();
 
     log.info('get [%s] different profiles',ids.length);
+
+    if (_.isEmpty(ids)) {
+      return cb(messages);
+    }
 
     seagullHandler.resolveUsers(ids, function(resolvedUsers){
 
       var resolvedMessages = _.map(messages, function(message) {
-        message.user = resolvedUsers[message.userid];
+        var resolvedUser = resolvedUsers[message.userid];
+        if (resolvedUser) {
+          message.user = resolvedUser;
+        }
         return message;
       });
 
@@ -330,15 +337,15 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
       metrics.postThisUser('replyToThread', {}, req._sessionToken);
 
       var missing = validate.incomingReply(req.params.message);
-     
+
       if( !_.isEmpty(missing) ){
         log.warn('Missing [%j]',missing);
         res.send(400,JSON.stringify(missing));
         return next();
       } else {
-     
+
         var reply = format.incomingReply(req._tokendata.userid, req._message, req.params.message);
-     
+
         crudHandler.createMessage(reply,function(error,messageId){
           if(error){
             log.error(error, 'Error adding message[%j]', reply);

--- a/lib/validation/format.js
+++ b/lib/validation/format.js
@@ -1,14 +1,14 @@
 // == BSD2 LICENSE ==
 // Copyright (c) 2014, Tidepool Project
-// 
+//
 // This program is free software; you can redistribute it and/or modify it under
 // the terms of the associated License, which is identical to the BSD 2-Clause
 // License as published by the Open Source Initiative at opensource.org.
-// 
+//
 // This program is distributed in the hope that it will be useful, but WITHOUT
 // ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 // FOR A PARTICULAR PURPOSE. See the License for more details.
-// 
+//
 // You should have received a copy of the License along with this program; if
 // not, you can obtain one from Tidepool Project at tidepool.org.
 // == BSD2 LICENSE ==
@@ -65,7 +65,7 @@ exports.incomingEdit = function(edits)
 
 exports.outgoingMessage = function(data,id)
 {
-  return {
+  var message = {
     id : id,
     guid : data.guid,
     parentmessage : data.parentmessage,
@@ -75,5 +75,11 @@ exports.outgoingMessage = function(data,id)
     createdtime : data.createdtime,
     messagetext : data.messagetext
   };
+
+  if (!_.isEmpty(data.user)) {
+    message.user = data.user;
+  }
+
+  return message;
 };
 

--- a/test/integration/mongoHandler_integration_tests.js
+++ b/test/integration/mongoHandler_integration_tests.js
@@ -203,7 +203,7 @@ describe('mongo handler', function() {
 
   });
 
-  describe('getting messages using ', function() {
+  describe('getting messages using', function() {
 
     var groupId = '123-456-99-100';
     var idOfParentMessage;
@@ -255,18 +255,20 @@ describe('mongo handler', function() {
       /*
        * Load multiple messages for testing
        */
-      testDbInstance.messages.remove();
-      var messages = testMessages();
+      testDbInstance.messages.remove(function(err) {
+        var messages = testMessages();
 
-      _.forEach(messages, function(message){
-        if(message.messagetext === 'this is the parentmessage'){
+        var pending = messages.length;
+        _.forEach(messages, function(message){
           testDbInstance.messages.save(message,function(err,doc){
-            idOfParentMessage = String(doc._id);
-            done();
+            if(doc.messagetext === 'this is the parentmessage'){
+              idOfParentMessage = String(doc._id);
+            }
+            if (--pending === 0) {
+              done();
+            }
           });
-        } else {
-          testDbInstance.messages.save(message);
-        }
+        });
       });
 
     });


### PR DESCRIPTION
@jh-bate The three commits detail exactly what was done.

Regarding delete user, normally a message in the database contains a userid field and the message-api service resolves that userid (via seagull) to a full user profile and adds it to the message before returning. However, when a user is deleted their profile no longer exists. So, during the delete user process, any messages created by the deleted user are updated to directly contain their user profile and the userid field is removed. So, this code was updated to support this directly embedded user profile without a userid.