### PR TITLE
Date parsing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,4 +26,4 @@ echo "Running tests"
 trap "cleanup ${MONGO_PID}" EXIT
 
 # run tests
-# ./node_modules/.bin/grunt test
+./node_modules/.bin/grunt test

--- a/build.sh
+++ b/build.sh
@@ -26,4 +26,4 @@ echo "Running tests"
 trap "cleanup ${MONGO_PID}" EXIT
 
 # run tests
-./node_modules/.bin/grunt test
+# ./node_modules/.bin/grunt test

--- a/lib/routes/messageApi.js
+++ b/lib/routes/messageApi.js
@@ -20,6 +20,7 @@ var sundial = require('sundial');
 var log = require('../log.js')('messageApi.js');
 var format = require('../validation/format');
 var validate = require('../validation/validate');
+var utility = require('./utility.js')();
 
 /*
  *  Messaging API implementation
@@ -61,15 +62,6 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
 
       return cb(resolvedMessages);
     });
-  }
-  /*
-   * Get the ISO String from the given date param
-   */
-  function getDateFromParam(datetime){
-    if(datetime){
-      return new Date(datetime).toISOString();
-    }
-    return null;
   }
   /*
    * From set when the deletion
@@ -159,8 +151,8 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
 
       //if a date that is passed is invalid then lets exit here
       try {
-        startDate = getDateFromParam(req.params.starttime);
-        endDate = getDateFromParam(req.params.endtime);
+        startDate = utility.getISODate(req.params.starttime);
+        endDate = utility.getISODate(req.params.endtime);
       } catch (error) {
         res.send(400);
         return next();
@@ -211,8 +203,8 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
 
       //if a date that is passed is invalid then lets exit here
       try {
-        startDate = getDateFromParam(req.params.starttime);
-        endDate = getDateFromParam(req.params.endtime);
+        startDate = utility.getISODate(req.params.starttime);
+        endDate = utility.getISODate(req.params.endtime);
       } catch (error) {
         res.send(400);
         return next();

--- a/lib/routes/messageApi.js
+++ b/lib/routes/messageApi.js
@@ -154,6 +154,7 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
         startDate = utility.getISODate(req.params.starttime);
         endDate = utility.getISODate(req.params.endtime);
       } catch (error) {
+        log.error(error, 'findAllById error parsing dates start[%s] end[%s]', startDate, endDate);
         res.send(400);
         return next();
       }
@@ -206,6 +207,7 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
         startDate = utility.getISODate(req.params.starttime);
         endDate = utility.getISODate(req.params.endtime);
       } catch (error) {
+        log.error(error, 'getNotes error parsing dates start[%s] end[%s]', startDate, endDate);
         res.send(400);
         return next();
       }

--- a/lib/routes/messageApi.js
+++ b/lib/routes/messageApi.js
@@ -151,10 +151,8 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
 
       //if a date that is passed is invalid then lets exit here
       try {
-        log.info('findAllById parsing dates start[%s] end[%s]', req.params.starttime, req.params.endtime);
         startDate = utility.getISODate(req.params.starttime);
         endDate = utility.getISODate(req.params.endtime);
-        log.info('findAllById parsed dates start[%s] end[%s]', startDate, endDate);
       } catch (error) {
         log.error(error, 'findAllById error parsing dates start[%s] end[%s]', startDate, endDate);
         res.send(400);

--- a/lib/routes/messageApi.js
+++ b/lib/routes/messageApi.js
@@ -151,8 +151,10 @@ module.exports = function(config, crudHandler, seagullHandler, metrics) {
 
       //if a date that is passed is invalid then lets exit here
       try {
+        log.info('findAllById parsing dates start[%s] end[%s]', req.params.starttime, req.params.endtime);
         startDate = utility.getISODate(req.params.starttime);
         endDate = utility.getISODate(req.params.endtime);
+        log.info('findAllById parsed dates start[%s] end[%s]', startDate, endDate);
       } catch (error) {
         log.error(error, 'findAllById error parsing dates start[%s] end[%s]', startDate, endDate);
         res.send(400);

--- a/lib/routes/utility.js
+++ b/lib/routes/utility.js
@@ -19,16 +19,21 @@ var _ = require('lodash');
 module.exports = function() {
 
   function toISODateString(d) {
-    function pad(n) {
-      return n<10 ? '0'+n : n;
+    function pad(number) {
+      if (number < 10) {
+        return '0' + number;
+      }
+      return number;
     }
-    return d.getUTCFullYear() + '-' +
-      pad(d.getUTCMonth() +1 ) + '-' +
-      pad(d.getUTCDate()) + 'T' +
-      pad(d.getUTCHours()) +':' +
-      pad(d.getUTCMinutes()) + ':' +
-      pad(d.getUTCSeconds()) + '.' +
-      pad(d.getMilliseconds()) + 'Z';
+
+    return d.getUTCFullYear() +
+      '-' + pad(d.getUTCMonth() + 1) +
+      '-' + pad(d.getUTCDate()) +
+      'T' + pad(d.getUTCHours()) +
+      ':' + pad(d.getUTCMinutes()) +
+      ':' + pad(d.getUTCSeconds()) +
+      '.' + (d.getUTCMilliseconds() / 1000).toFixed(3).slice(2, 5) +
+      'Z';
   }
 
 

--- a/lib/routes/utility.js
+++ b/lib/routes/utility.js
@@ -15,9 +15,23 @@
 
 'use strict';
 var _ = require('lodash');
-var sundial = require('sundial');
 
 module.exports = function() {
+
+  function toISODateString(d) {
+    function pad(n) {
+      return n<10 ? '0'+n : n;
+    }
+    return d.getUTCFullYear() + '-' +
+      pad(d.getUTCMonth() +1 ) + '-' +
+      pad(d.getUTCDate()) + 'T' +
+      pad(d.getUTCHours()) +':' +
+      pad(d.getUTCMinutes()) + ':' +
+      pad(d.getUTCSeconds()) + '.' +
+      pad(d.getMilliseconds()) + 'Z';
+  }
+
+
   return {
     /*
      * get the date as an ISO 8601 string from any valid datetime YYYY-MM-DDTHH:mm:ss.sssZ string
@@ -29,21 +43,8 @@ module.exports = function() {
       if (_.isEmpty(datetime)) {
         return null;
       }
-      function ISODateString(d) {
-        function pad(n) {
-          return n<10 ? '0'+n : n;
-        }
-        return d.getUTCFullYear()+'-'
-          + pad(d.getUTCMonth()+1)+'-'
-          + pad(d.getUTCDate())+'T'
-          + pad(d.getUTCHours())+':'
-          + pad(d.getUTCMinutes())+':'
-          + pad(d.getUTCSeconds())+'.'
-          + pad(d.getMilliseconds())+'Z';
-      }
       var rawDate = new Date(datetime);
-
-      return ISODateString(rawDate);
+      return toISODateString(rawDate);
     }
   };
 };

--- a/lib/routes/utility.js
+++ b/lib/routes/utility.js
@@ -28,6 +28,7 @@ module.exports = function() {
       if (_.isEmpty(datetime)) {
         return null;
       }
+      //NOTE: this is a fix for when the `+` wasn't escaped on the incoming request
       datetime = datetime.replace(' ', '+');
       return new Date(datetime).toISOString();
     }

--- a/lib/routes/utility.js
+++ b/lib/routes/utility.js
@@ -29,7 +29,7 @@ module.exports = function() {
       if (_.isEmpty(datetime)) {
         return null;
       }
-      return new Date(datetime).toISOString();
+      return sundial.formatDeviceTime(datetime);
     },
     /*
      * get the date as an ISO 8601 string from any valid datetime formatted string

--- a/lib/routes/utility.js
+++ b/lib/routes/utility.js
@@ -17,25 +17,6 @@
 var _ = require('lodash');
 
 module.exports = function() {
-
-  function toISODateString(d) {
-    function pad(number) {
-      if (number < 10) {
-        return '0' + number;
-      }
-      return number;
-    }
-
-    return d.getUTCFullYear() +
-      '-' + pad(d.getUTCMonth() + 1) +
-      '-' + pad(d.getUTCDate()) +
-      'T' + pad(d.getUTCHours()) +
-      ':' + pad(d.getUTCMinutes()) +
-      ':' + pad(d.getUTCSeconds()) +
-      '.' + (d.getUTCMilliseconds() / 1000).toFixed(3).slice(2, 5) +
-      'Z';
-  }
-
   return {
     /*
      * get the date as an ISO 8601 string from any valid datetime YYYY-MM-DDTHH:mm:ss.sssZ string
@@ -48,8 +29,7 @@ module.exports = function() {
         return null;
       }
       datetime = datetime.replace(' ', '+');
-      var rawDate = new Date(datetime);
-      return toISODateString(rawDate);
+      return new Date(datetime).toISOString();
     }
   };
 };

--- a/lib/routes/utility.js
+++ b/lib/routes/utility.js
@@ -36,7 +36,6 @@ module.exports = function() {
       'Z';
   }
 
-
   return {
     /*
      * get the date as an ISO 8601 string from any valid datetime YYYY-MM-DDTHH:mm:ss.sssZ string
@@ -48,6 +47,7 @@ module.exports = function() {
       if (_.isEmpty(datetime)) {
         return null;
       }
+      datetime = datetime.replace(' ', '+');
       var rawDate = new Date(datetime);
       return toISODateString(rawDate);
     }

--- a/lib/routes/utility.js
+++ b/lib/routes/utility.js
@@ -29,19 +29,21 @@ module.exports = function() {
       if (_.isEmpty(datetime)) {
         return null;
       }
-      return sundial.formatDeviceTime(datetime);
-    },
-    /*
-     * get the date as an ISO 8601 string from any valid datetime formatted string
-     *
-     * @param {string} datetime
-     * @return {string} ISO 8601 string or null
-     */
-    getDateFromParam : function(datetime) {
-      if (_.isEmpty(datetime)) {
-        return null;
+      function ISODateString(d) {
+        function pad(n) {
+          return n<10 ? '0'+n : n;
+        }
+        return d.getUTCFullYear()+'-'
+          + pad(d.getUTCMonth()+1)+'-'
+          + pad(d.getUTCDate())+'T'
+          + pad(d.getUTCHours())+':'
+          + pad(d.getUTCMinutes())+':'
+          + pad(d.getUTCSeconds())+'.'
+          + pad(d.getMilliseconds())+'Z';
       }
-      return sundial.formatFromOffset(datetime, sundial.getOffsetFromTime(datetime) ,'YYYY-MM-DDTHH:mm:ss.sssZ');
+      var rawDate = new Date(datetime);
+
+      return ISODateString(rawDate);
     }
   };
 };

--- a/lib/routes/utility.js
+++ b/lib/routes/utility.js
@@ -1,0 +1,47 @@
+// == BSD2 LICENSE ==
+// Copyright (c) 2016, Tidepool Project
+//
+// This program is free software; you can redistribute it and/or modify it under
+// the terms of the associated License, which is identical to the BSD 2-Clause
+// License as published by the Open Source Initiative at opensource.org.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the License for more details.
+//
+// You should have received a copy of the License along with this program; if
+// not, you can obtain one from Tidepool Project at tidepool.org.
+// == BSD2 LICENSE ==
+
+'use strict';
+var _ = require('lodash');
+var sundial = require('sundial');
+
+module.exports = function() {
+  return {
+    /*
+     * get the date as an ISO 8601 string from any valid datetime YYYY-MM-DDTHH:mm:ss.sssZ string
+     *
+     * @param {string} datetime
+     * @return {string} ISO 8601 string or null
+     */
+    getISODate: function(datetime) {
+      if (_.isEmpty(datetime)) {
+        return null;
+      }
+      return new Date(datetime).toISOString();
+    },
+    /*
+     * get the date as an ISO 8601 string from any valid datetime formatted string
+     *
+     * @param {string} datetime
+     * @return {string} ISO 8601 string or null
+     */
+    getDateFromParam : function(datetime) {
+      if (_.isEmpty(datetime)) {
+        return null;
+      }
+      return sundial.formatFromOffset(datetime, sundial.getOffsetFromTime(datetime) ,'YYYY-MM-DDTHH:mm:ss.sssZ');
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-api",
-  "version": "0.7.4-alpha",
+  "version": "0.7.5-alpha",
   "description": "Tidepool Message API.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-api",
-  "version": "0.7.3-alpha",
+  "version": "0.7.4-alpha",
   "description": "Tidepool Message API.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-api",
-  "version": "0.7.6-alpha",
+  "version": "0.7.7-alpha",
   "description": "Tidepool Message API.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-api",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Tidepool Message API.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-api",
-  "version": "0.7.2-alpha",
+  "version": "0.7.3-alpha",
   "description": "Tidepool Message API.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-api",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Tidepool Message API.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-api",
-  "version": "0.7.7-alpha",
+  "version": "0.7.8",
   "description": "Tidepool Message API.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-api",
-  "version": "0.7.5-alpha",
+  "version": "0.7.6-alpha",
   "description": "Tidepool Message API.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-api",
-  "version": "0.7.0-alpha",
+  "version": "0.7.1-alpha",
   "description": "Tidepool Message API.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-api",
-  "version": "0.6.0",
+  "version": "0.7.0-alpha",
   "description": "Tidepool Message API.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-api",
-  "version": "0.7.1-alpha",
+  "version": "0.7.2-alpha",
   "description": "Tidepool Message API.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-api",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Tidepool Message API.",
   "main": "lib/index.js",
   "directories": {

--- a/test/unit/utility_tests.js
+++ b/test/unit/utility_tests.js
@@ -54,5 +54,4 @@ describe('utility', function() {
       done();
     });
   });
-
 });

--- a/test/unit/utility_tests.js
+++ b/test/unit/utility_tests.js
@@ -35,16 +35,22 @@ describe('utility', function() {
       expect(returnedDate).to.equal('2015-12-21T00:00:00.000Z');
       done();
     });
-    it('date, time and offset', function(done) {
+    it('date, time and offset + UTC', function(done) {
       var returnedDate = utility.getISODate('2016-12-22T16:27:10+13:00');
       expect(returnedDate).to.exist;
       expect(returnedDate).to.equal('2016-12-22T03:27:10.000Z');
       done();
     });
-    it('date, time and offset', function(done) {
+    it('date, time and offset UTC', function(done) {
       var returnedDate = utility.getISODate('2016-12-22T16:27:10 13:00');
       expect(returnedDate).to.exist;
       expect(returnedDate).to.equal('2016-12-22T03:27:10.000Z');
+      done();
+    });
+    it('date, time and offset - UTC', function(done) {
+      var returnedDate = utility.getISODate('2016-12-22T16:27:10-08:00');
+      expect(returnedDate).to.exist;
+      expect(returnedDate).to.equal('2016-12-23T00:27:10.000Z');
       done();
     });
   });

--- a/test/unit/utility_tests.js
+++ b/test/unit/utility_tests.js
@@ -1,0 +1,46 @@
+    // == BSD2 LICENSE ==
+// Copyright (c) 2014, Tidepool Project
+//
+// This program is free software; you can redistribute it and/or modify it under
+// the terms of the associated License, which is identical to the BSD 2-Clause
+// License as published by the Open Source Initiative at opensource.org.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the License for more details.
+//
+// You should have received a copy of the License along with this program; if
+// not, you can obtain one from Tidepool Project at tidepool.org.
+// == BSD2 LICENSE ==
+
+'use strict';
+
+var salinity = require('salinity');
+var expect = salinity.expect;
+
+describe('utility', function() {
+
+  var utility = require('../../lib/routes/utility')();
+
+  describe('getDateFromParam', function() {
+    it('date and time', function(done) {
+      var returnedDate = utility.getISODate('2015-12-21T15:20:33');
+      expect(returnedDate).to.exist;
+      expect(returnedDate).to.equal('2015-12-21T15:20:33.000Z');
+      done();
+    });
+    it('date', function(done) {
+      var returnedDate = utility.getISODate('2015-12-21');
+      expect(returnedDate).to.exist;
+      expect(returnedDate).to.equal('2015-12-21T00:00:00.000Z');
+      done();
+    });
+    it('date, time and offset', function(done) {
+      var returnedDate = utility.getISODate('2016-12-22T16:27:10+13:00');
+      expect(returnedDate).to.exist;
+      expect(returnedDate).to.equal('2016-12-22T03:27:10.000Z');
+      done();
+    });
+  });
+
+});

--- a/test/unit/utility_tests.js
+++ b/test/unit/utility_tests.js
@@ -26,19 +26,19 @@ describe('utility', function() {
     it('date and time', function(done) {
       var returnedDate = utility.getISODate('2015-12-21T15:20:33');
       expect(returnedDate).to.exist;
-      expect(returnedDate).to.equal('2015-12-21T15:20:33.00Z');
+      expect(returnedDate).to.equal('2015-12-21T15:20:33.000Z');
       done();
     });
     it('date', function(done) {
       var returnedDate = utility.getISODate('2015-12-21');
       expect(returnedDate).to.exist;
-      expect(returnedDate).to.equal('2015-12-21T00:00:00.00Z');
+      expect(returnedDate).to.equal('2015-12-21T00:00:00.000Z');
       done();
     });
     it('date, time and offset', function(done) {
       var returnedDate = utility.getISODate('2016-12-22T16:27:10+13:00');
       expect(returnedDate).to.exist;
-      expect(returnedDate).to.equal('2016-12-22T03:27:10.00Z');
+      expect(returnedDate).to.equal('2016-12-22T03:27:10.000Z');
       done();
     });
   });

--- a/test/unit/utility_tests.js
+++ b/test/unit/utility_tests.js
@@ -41,6 +41,12 @@ describe('utility', function() {
       expect(returnedDate).to.equal('2016-12-22T03:27:10.000Z');
       done();
     });
+    it('date, time and offset', function(done) {
+      var returnedDate = utility.getISODate('2016-12-22T16:27:10 13:00');
+      expect(returnedDate).to.exist;
+      expect(returnedDate).to.equal('2016-12-22T03:27:10.000Z');
+      done();
+    });
   });
 
 });

--- a/test/unit/utility_tests.js
+++ b/test/unit/utility_tests.js
@@ -26,19 +26,19 @@ describe('utility', function() {
     it('date and time', function(done) {
       var returnedDate = utility.getISODate('2015-12-21T15:20:33');
       expect(returnedDate).to.exist;
-      expect(returnedDate).to.equal('2015-12-21T15:20:33');
+      expect(returnedDate).to.equal('2015-12-21T15:20:33.00Z');
       done();
     });
     it('date', function(done) {
       var returnedDate = utility.getISODate('2015-12-21');
       expect(returnedDate).to.exist;
-      expect(returnedDate).to.equal('2015-12-21T00:00:00');
+      expect(returnedDate).to.equal('2015-12-21T00:00:00.00Z');
       done();
     });
     it('date, time and offset', function(done) {
       var returnedDate = utility.getISODate('2016-12-22T16:27:10+13:00');
       expect(returnedDate).to.exist;
-      expect(returnedDate).to.equal('2016-12-22T03:27:10');
+      expect(returnedDate).to.equal('2016-12-22T03:27:10.00Z');
       done();
     });
   });

--- a/test/unit/utility_tests.js
+++ b/test/unit/utility_tests.js
@@ -26,19 +26,19 @@ describe('utility', function() {
     it('date and time', function(done) {
       var returnedDate = utility.getISODate('2015-12-21T15:20:33');
       expect(returnedDate).to.exist;
-      expect(returnedDate).to.equal('2015-12-21T15:20:33.000Z');
+      expect(returnedDate).to.equal('2015-12-21T15:20:33');
       done();
     });
     it('date', function(done) {
       var returnedDate = utility.getISODate('2015-12-21');
       expect(returnedDate).to.exist;
-      expect(returnedDate).to.equal('2015-12-21T00:00:00.000Z');
+      expect(returnedDate).to.equal('2015-12-21T00:00:00');
       done();
     });
     it('date, time and offset', function(done) {
       var returnedDate = utility.getISODate('2016-12-22T16:27:10+13:00');
       expect(returnedDate).to.exist;
-      expect(returnedDate).to.equal('2016-12-22T03:27:10.000Z');
+      expect(returnedDate).to.equal('2016-12-22T03:27:10');
       done();
     });
   });


### PR DESCRIPTION
@darinkrauss this resolves the issue that we were having with dates from the notes app - I have tested on devel with a simulator version of the notes app

So the reason that Lennart and I get this issue is we are in `+` UTC timezones to the `+13:00` wasn't escaped so it would drop that from the time and then when doing the conversion blow up. I know its an assumption that I have built in but let me know if its not acceptable as a band aid 